### PR TITLE
If no stop-time-updates are available, set availability to zero

### DIFF
--- a/src/realtime_metrics/main.py
+++ b/src/realtime_metrics/main.py
@@ -64,7 +64,10 @@ def run_analysis():
         trip_availability = availability_acceptable_stop_time_updates(trip_updates, time_frame_start, time_frame_end)
         availabilities.append(trip_availability)
 
-    availability_acceptable_stop_time_updates_result = sum(availabilities) / len(availabilities)
+    if len(availabilities) == 0:
+        availability_acceptable_stop_time_updates_result = 0
+    else:
+        availability_acceptable_stop_time_updates_result = sum(availabilities) / len(availabilities)
 
     print("Availability of acceptable stop time updates: ", availability_acceptable_stop_time_updates_result)
 


### PR DESCRIPTION
This avoids a division-by-zero crash.

Also from a semantic point of view, this makes sense as well, because if there are no updates at all, availability is zero.