### PR TITLE
Feature/experienced wait time delay

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python Debugger: Current File with Arguments",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${file}",
+            "console": "integratedTerminal",
+            "args": "-d sqlite:///example.db -v ${command:pickArgs}"
+        },
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ Evaluate recorded GTFS-RT data
 
 [GTFSDB](https://github.com/OpenTransitTools/gtfsdb) (to load the dataset into the db) is needed:
 
-
 ```shell
 pip install git+https://github.com/1Maxnet1/gtfsdb.git@patch-1 setuptools # workaround until dependency issues are resolved upstream
 ```
@@ -29,7 +28,7 @@ pip uninstall sqlalchemy
 pip install -e .
 ```
 
-This does also install [gtfsrdb](https://github.com/public-transport/gtfsrdb). 
+This does also install [gtfsrdb](https://github.com/public-transport/gtfsrdb).
 
 Afterwards, use gtfsrdb to collect some realtime data:
 

--- a/src/realtime_metrics/main.py
+++ b/src/realtime_metrics/main.py
@@ -57,13 +57,13 @@ def run_analysis():
     if eta_accuracy_result is None:
         print("ETA accuracy could not be computed, no data provided!")
     else:
-        print("ETA accuracy: ", eta_accuracy_result)
+        print(f"ETA accuracy: {eta_accuracy_result}%")
 
     experienced_wait_time_delay_result = experienced_wait_time_delay(stop_time_updates)
     if experienced_wait_time_delay_result is None:
         print("Experienced Wait Time Delay could not be computed, no data provided!")
     else:
-        print("Experienced Wait Time Delay: ", experienced_wait_time_delay_result)
+        print(f"Experienced Wait Time Delay: {experienced_wait_time_delay_result} seconds")
 
     availabilities = []
     
@@ -77,7 +77,7 @@ def run_analysis():
     else:
         availability_acceptable_stop_time_updates_result = sum(availabilities) / len(availabilities)
 
-    print("Availability of acceptable stop time updates: ", availability_acceptable_stop_time_updates_result)
+    print(f"Availability of acceptable stop time updates: {availability_acceptable_stop_time_updates_result}%")
 
 
 def mse_accuracy(stop_time_updates: list[tuple[TripUpdate, StopTimeUpdate]]) -> float | None:
@@ -102,7 +102,7 @@ def mse_accuracy(stop_time_updates: list[tuple[TripUpdate, StopTimeUpdate]]) -> 
         samples.append(prediction_error)
 
     # compute MSE
-    if len(samples) <= 0:
+    if len(samples) == 0:
         logger.info("No data provided!")
         return None
 
@@ -317,7 +317,7 @@ def availability_acceptable_stop_time_updates(stop_time_updates: list[tuple[Trip
     """
     Computes the availability of acceptable stop time updates metrics for the given stop time updates in the given time frame.
     The metric is defined here: https://docs.google.com/document/d/1-AOtPaEViMcY6B5uTAYj7oVkwry3LfAQJg3ihSRTVoU. 
-    It computes the percentage of one minute slots with two or more updates.
+    It computes the percentage of one-minute slots with two or more updates.
 
     Parameters:
     stop_time_updates: list of corresponding trip updates and stop time updates
@@ -376,7 +376,7 @@ def get_last_predicted_update(timestamp: int, updates: list[tuple[TripUpdate, St
     return updates_published_at_last_timestamp[0]
 
 
-def get_next_actual_arrival(timestamp: int, route_id: int, stop_id: int) -> StopTimeUpdate | None:
+def get_next_actual_arrival(timestamp: int, route_id: str, stop_id: str) -> StopTimeUpdate | None:
     """
     Returns the stop time update containing the next actual arrival time for the given route and stop after the given timestamp.
     """

--- a/src/realtime_metrics/main.py
+++ b/src/realtime_metrics/main.py
@@ -2,7 +2,7 @@ import logging
 import sys
 from optparse import OptionParser
 from typing import Dict
-from datetime import datetime
+from datetime import datetime, timezone
 
 from gtfsrdb.model import Base, TripUpdate, StopTimeUpdate
 from sqlalchemy import create_engine, inspect
@@ -34,10 +34,10 @@ def run_analysis():
             if stop_time_update.arrival_uncertainty > 0:
                 continue # only consider updates with arrival uncertainty 0 as actual arrivals
             if key in actual_arrival_times.keys():
-                if tripUpdate.timestamp.timestamp() > actual_arrival_times[key][0]:
-                    actual_arrival_times[key] = (tripUpdate.timestamp.timestamp(), stop_time_update)
+                if tripUpdate.timestamp.replace(tzinfo=timezone.utc).timestamp() > actual_arrival_times[key][0]:
+                    actual_arrival_times[key] = (tripUpdate.timestamp.replace(tzinfo=timezone.utc).timestamp(), stop_time_update)
             else:
-                actual_arrival_times[key] = (tripUpdate.timestamp.timestamp(), stop_time_update)
+                actual_arrival_times[key] = (tripUpdate.timestamp.replace(tzinfo=timezone.utc).timestamp(), stop_time_update)
 
             # add stop time update to trips
             if key in trips.keys():
@@ -133,7 +133,7 @@ def eta_accuracy(stop_time_updates: list[tuple[TripUpdate, StopTimeUpdate]]) -> 
         actual_arrival_time = get_actual_arrival_time(trip_update=trip_update, stop_time_update=stop_time_update)
         if actual_arrival_time is None:
             continue # skip updates with unknown actual arrival time
-        time_variance = actual_arrival_time - trip_update.timestamp.timestamp()
+        time_variance = actual_arrival_time - trip_update.timestamp.replace(tzinfo=timezone.utc).timestamp()
 
         bucket_index = 0
         upper_limit = 0
@@ -276,17 +276,17 @@ def experienced_wait_time_delay(trip_stop_time_updates: list[tuple[TripUpdate, S
             continue
         route_id, stop_id = index_key
         # sort updates by published time
-        trip_stop_updates.sort(key=lambda u: u[0].timestamp.timestamp())
-        logger.debug("Sorted updates for %s: %s", index_key, [datetime.fromtimestamp(update[0].timestamp.timestamp()).strftime("%Y-%m-%d %H:%M:%S") for update in trip_stop_updates])
+        trip_stop_updates.sort(key=lambda u: u[0].timestamp.replace(tzinfo=timezone.utc).timestamp())
+        logger.debug("Sorted updates for %s: %s", index_key, [datetime.fromtimestamp(update[0].timestamp.replace(tzinfo=timezone.utc).timestamp()).strftime("%Y-%m-%d %H:%M:%S") for update in trip_stop_updates])
 
         # Determine the range of days based on arrival times
-        min_arrival_time = trip_stop_updates[0][0].timestamp.timestamp()
-        max_arrival_time = trip_stop_updates[-1][0].timestamp.timestamp()
+        min_arrival_time = trip_stop_updates[0][0].timestamp.replace(tzinfo=timezone.utc).timestamp()
+        max_arrival_time = trip_stop_updates[-1][0].timestamp.replace(tzinfo=timezone.utc).timestamp()
 
-        current_time = min_arrival_time
+        current_time = min_arrival_time - (min_arrival_time % 60)
         end_time = max_arrival_time
 
-        for current_time in range(int(min_arrival_time), int(end_time) + 1, 60):
+        for current_time in range(int(current_time), int(end_time) + 1, 60):
             # find the last stop time update
             next_predicted_arrival = get_last_predicted_update(current_time, trip_stop_updates)
             if not next_predicted_arrival:
@@ -302,7 +302,7 @@ def experienced_wait_time_delay(trip_stop_time_updates: list[tuple[TripUpdate, S
             delay = next_actual_arrival_time - next_predicted_arrival_time
             delays.append(delay)
 
-    if not delays:
+    if len(delays) <= 0:
         logger.info("No delay samples found.")
         return None
 
@@ -337,7 +337,7 @@ def availability_acceptable_stop_time_updates(stop_time_updates: list[tuple[Trip
         trip_update = update[0]
 
         # get time in minutes
-        time_in_minutes = int(trip_update.timestamp.timestamp() / 60)
+        time_in_minutes = int(trip_update.timestamp.replace(tzinfo=timezone.utc).timestamp() / 60)
 
         # skip, if outide of time frame
         if time_in_minutes < time_frame_start or time_in_minutes > time_frame_end:
@@ -367,11 +367,11 @@ def get_last_predicted_update(timestamp: int, updates: list[tuple[TripUpdate, St
     Returns the last stop time update in the given list, that what published before or at the given timestamp.
     If no such stop time update is in the list, None is returned.
     """
-    updates_before_timestamp = [update for update in updates if update[0].timestamp.timestamp() <= timestamp]
+    updates_before_timestamp = [update for update in updates if update[0].timestamp.replace(tzinfo=timezone.utc).timestamp() <= timestamp and update[1].arrival_time > 0]
     if len(updates_before_timestamp) <= 0:
         return None
-    latest_timestamp = updates_before_timestamp[-1][0].timestamp.timestamp()
-    updates_published_at_last_timestamp = [update for update in updates_before_timestamp if update[0].timestamp.timestamp() == latest_timestamp]
+    latest_timestamp = updates_before_timestamp[-1][0].timestamp.replace(tzinfo=timezone.utc).timestamp()
+    updates_published_at_last_timestamp = [update for update in updates_before_timestamp if update[0].timestamp.replace(tzinfo=timezone.utc).timestamp() == latest_timestamp]
     updates_published_at_last_timestamp.sort(key=lambda update: update[1].arrival_time)
     return updates_published_at_last_timestamp[0]
 

--- a/src/realtime_metrics/main.py
+++ b/src/realtime_metrics/main.py
@@ -28,9 +28,17 @@ def run_analysis():
         for trip_stop_time_update in trip_stop_time_updates:
             stop_time_updates.append((trip_stop_time_update.TripUpdate, trip_stop_time_update.StopTimeUpdate))
 
-            # add stop_time_update to dictionary if not present or update if timestamp of tripUpdate is newer than the one in the dictionary
+            # add stop time update to trips
             stop_time_update: StopTimeUpdate = trip_stop_time_update.StopTimeUpdate
             key = (tripUpdate.route_id, tripUpdate.trip_id, stop_time_update.stop_id)
+            if key in trips.keys():
+                trip_updates: list[TripUpdate] = trips[key]
+            else:
+                trip_updates: list[TripUpdate] = []
+            trip_updates.append((trip_stop_time_update.TripUpdate, trip_stop_time_update.StopTimeUpdate))
+            trips[key] = trip_updates
+
+            # add stop_time_update to dictionary if not present or update if timestamp of tripUpdate is newer than the one in the dictionary
             if stop_time_update.arrival_uncertainty > 0:
                 continue # only consider updates with arrival uncertainty 0 as actual arrivals
             if key in actual_arrival_times.keys():
@@ -38,14 +46,6 @@ def run_analysis():
                     actual_arrival_times[key] = (tripUpdate.timestamp.replace(tzinfo=timezone.utc).timestamp(), stop_time_update)
             else:
                 actual_arrival_times[key] = (tripUpdate.timestamp.replace(tzinfo=timezone.utc).timestamp(), stop_time_update)
-
-            # add stop time update to trips
-            if key in trips.keys():
-                trip_updates: list[TripUpdate] = trips[key]
-            else:
-                trip_updates: list[TripUpdate] = []
-            trip_updates.append((trip_stop_time_update.TripUpdate, trip_stop_time_update.StopTimeUpdate))
-            trips[key] = trip_updates
 
     mse_accuracy_result = mse_accuracy(stop_time_updates=stop_time_updates)
     if mse_accuracy_result is None:


### PR DESCRIPTION
Closes https://github.com/SWT-Forschungsprojekt/planning/issues/24

This implements the `Experienced Wait Time Delay` metric specified [here](https://docs.google.com/document/d/1-AOtPaEViMcY6B5uTAYj7oVkwry3LfAQJg3ihSRTVoU).

Additionally, the estimation of actual arrival times and delays now only considers stop time updates with uncertainty 0. 
This is adapted in the accuracy metrics to not include updates without valid actual arrival time and delay.