### PR TITLE
Grammar fixes and gtfsrdb command corrected -v mean verbose output (which is used to see e.g., the number of vehiclePositions) while -p stands for the vehiclePositions URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Evaluate recorded GTFS-RT data
 pip install git+https://github.com/1Maxnet1/gtfsdb.git@patch-1 setuptools # workaround until dependency issues are resolved upstream
 ```
 
-Now one download a GTFS dataset and load it into the database:
+Now one downloads a GTFS dataset and loads it into the database:
 
 ```shell
 wget -O BUCHAREST-REGION.zip https://gtfs.tpbi.ro/regional/BUCHAREST-REGION.zip
@@ -20,8 +20,8 @@ gtfsdb-load --database_url sqlite:///example.db BUCHAREST-REGION.zip
 Now install `realtime-metrics` package:
 
 > [!NOTE]  
-> Currently GTFSdb works only with SQLAlchemy version 1.x, while realtime-metrics requires SQLAlchemy version 2.x
-> Therefore they cannot work in the same environment at the same time
+> Currently GTFSdb works only with SQLAlchemy version 1.x, while realtime-metrics require SQLAlchemy version 2.x
+> Therefore, they cannot work in the same environment at the same time
 
 ```shell
 pip uninstall sqlalchemy
@@ -33,7 +33,7 @@ This does also install [gtfsrdb](https://github.com/public-transport/gtfsrdb).
 Afterwards, use gtfsrdb to collect some realtime data:
 
 ```shell
-gtfsrdb -t https://gtfs.tpbi.ro/api/gtfs-rt/tripUpdates -v https://gtfs.tpbi.ro/api/gtfs-rt/vehiclePositions -d sqlite:///example.db -c
+gtfsrdb -t https://gtfs.tpbi.ro/api/gtfs-rt/tripUpdates -p https://gtfs.tpbi.ro/api/gtfs-rt/vehiclePositions -d sqlite:///example.db -c -v
 ```
 
 Now you can run the script to calculate some metrics on it:


### PR DESCRIPTION
- grammar fixes
- the command for gtfsrdb was wrong: -v stands for verbose and -p for vehiclePositions URL