### PR TITLE
Fixed stop time availablity time frame

### DIFF
--- a/src/realtime_metrics/main.py
+++ b/src/realtime_metrics/main.py
@@ -79,8 +79,8 @@ def run_analysis():
         if len(trip_updates) == 0:
             continue
         trip_updates.sort(key=lambda u: u[0].timestamp.replace(tzinfo=timezone.utc).timestamp())
-        time_frame_start = int(trip_updates[0][0].timestamp.replace(tzinfo=timezone.utc).timestamp() / 60) * 60
-        time_frame_end = int(trip_updates[-1][0].timestamp.replace(tzinfo=timezone.utc).timestamp() / 60) * 60
+        time_frame_start = trip_updates[0][0].timestamp.replace(tzinfo=timezone.utc).replace(second=0).timestamp()
+        time_frame_end = trip_updates[-1][0].timestamp.replace(tzinfo=timezone.utc).replace(second=0).timestamp()
         trip_availability = availability_acceptable_stop_time_updates(trip_updates, time_frame_start, time_frame_end)
         availabilities.append(trip_availability)
 
@@ -372,9 +372,9 @@ def availability_acceptable_stop_time_updates(stop_time_updates: list[tuple[Trip
         trip_update = update[0]
 
         # get time in minutes by removing part of the timestamp responsible for seconds
-        time_rounded_in_minutes = int(trip_update.timestamp.replace(tzinfo=timezone.utc).timestamp() / 60) * 60
+        time_rounded_in_minutes = trip_update.timestamp.replace(tzinfo=timezone.utc).replace(second=0).timestamp()
 
-        # skip, if outide of time frame
+        # skip, if outside of time frame
         if time_rounded_in_minutes < time_frame_start or time_rounded_in_minutes > time_frame_end:
             continue
 

--- a/src/realtime_metrics/main.py
+++ b/src/realtime_metrics/main.py
@@ -83,7 +83,6 @@ def run_analysis():
         time_frame_end = int(trip_updates[-1][0].timestamp.replace(tzinfo=timezone.utc).timestamp() / 60) * 60
         trip_availability = availability_acceptable_stop_time_updates(trip_updates, time_frame_start, time_frame_end)
         availabilities.append(trip_availability)
-        break
 
     if len(availabilities) == 0:
         availability_acceptable_stop_time_updates_result = 0

--- a/src/realtime_metrics/main.py
+++ b/src/realtime_metrics/main.py
@@ -108,6 +108,7 @@ def run_stop_time_analysis():
     prediction_inconsistency_result = numpy.mean(inconsistencies)
     print(f"Prediction inconsistency: {round(prediction_inconsistency_result, 2)} seconds")
 
+
 def run_vehicle_position_analysis():
     """
     get all vehicle positions and compute the different metrics
@@ -417,6 +418,7 @@ def availability_acceptable_stop_time_updates(stop_time_updates: list[tuple[Trip
 
     return (time_slots_with_enough_updates / number_of_time_slots) * 100
 
+
 def availability_acceptable_vehicle_positions(vehicle_positions: list[VehiclePosition], 
                                               time_frame_start: datetime, 
                                               time_frame_end: datetime) -> float:
@@ -472,6 +474,8 @@ def availability_acceptable_vehicle_positions(vehicle_positions: list[VehiclePos
         return 0.0
 
     return time_slots_with_enough_updates / len(amount_vehicle_positions_per_minute) * 100
+
+
 def get_last_predicted_update(timestamp: int, updates: list[tuple[TripUpdate, StopTimeUpdate]]) -> tuple[TripUpdate, StopTimeUpdate] | None:
     """
     Returns the last stop time update in the given list, that what published before or at the given timestamp.


### PR DESCRIPTION
Changed the time frame to calculate the `availabiltiy of acceptable stop time updates` metric to use the first and last provided update for each trip and stop combination.

Previously, it was the first and last update published across all trip and stop combinations, but this was lost somewhere. As our test feed fulfills the required two updates per minute at no point, the result stayed the same (0.0%) as therefore was not noticed.

In the official definition, the time frame is defined as the `trip start time` up to the `actual arrival time`. In my opinion, this only makes sense if one observes the published stop time updates for this entire time, as otherwise many slots would be marked as having not enough updates, even if they have and we just did not capture them.

Therefore, I propose to use the time frame as the range we have stop time updates in, as this should be a good estimate for the entire trip.